### PR TITLE
MouseUp event added on the window a RELEASE_OUTSIDE event can be detected

### DIFF
--- a/lime/_backend/html5/HTML5Window.hx
+++ b/lime/_backend/html5/HTML5Window.hx
@@ -225,7 +225,7 @@ class HTML5Window {
 				
 			}
 			
-			//Release outside browser window
+			// Release outside browser window
 			Browser.window.addEventListener("mouseup", handleMouseEvent);
 			
 			// Disable image drag on Firefox

--- a/lime/_backend/html5/HTML5Window.hx
+++ b/lime/_backend/html5/HTML5Window.hx
@@ -225,6 +225,9 @@ class HTML5Window {
 				
 			}
 			
+			//Release outside browser window
+			Browser.window.addEventListener("mouseup", handleMouseEvent);
+			
 			// Disable image drag on Firefox
 			Browser.document.addEventListener ("dragstart", function (e) {
 				if (e.target.nodeName.toLowerCase () == "img") {
@@ -479,6 +482,8 @@ class HTML5Window {
 					}
 				
 				case "mouseup":
+					
+					event.stopPropagation ();
 					
 					parent.onMouseUp.dispatch (x, y, event.button);
 					


### PR DESCRIPTION
Currently mouse events are added to a div element and therefore releasing mouse outside of the browser window doesn't trigger mouseup event. A mouse up event listener is added to the window and it is only executed when mouse is released outside of the window. This way we catch the "RELEASE_OUTSIDE" event