### PR TITLE
fix gaussianBlur filter messing up colors and alpha

### DIFF
--- a/lime/graphics/utils/ImageDataUtil.hx
+++ b/lime/graphics/utils/ImageDataUtil.hx
@@ -510,23 +510,9 @@ class ImageDataUtil {
 		
 		// TODO: Support sourceRect better, do not modify sourceImage, create C++ implementation for native
 		
-		// TODO: Better handling of premultiplied alpha
-		var fromPreMult;
-		
 		if (image.buffer.premultiplied || sourceImage.buffer.premultiplied) {
-			
-			fromPreMult = function (col:Float, alpha:Float):Int {
-				var col = Std.int (col);
-				return col < 0 ? 0 : (col > 255 ? 255 : col);
-			}
-			
-		} else {
-			
-			fromPreMult = function (col:Float, alpha:Float):Int {
-				var col = Std.int (col / alpha * 255) ;
-				return col < 0 ? 0 : (col > 255 ? 255 : col);
-			}
-			
+			// TODO: Better handling of premultiplied alpha
+			throw "Pre-multiplied bitmaps are not supported";
 		}
 		
 		var boxesForGauss = function (sigma:Float, n:Int):Array<Float> {
@@ -656,7 +642,7 @@ class ImageDataUtil {
 			while (y < h) {
 				x = 0;
 				while (x < w) {
-					translatePixel(imgB, sourceImage.rect, image.rect, destPoint, x, y, strength, fromPreMult);
+					translatePixel(imgB, sourceImage.rect, image.rect, destPoint, x, y, strength);
 					x += 1;
 				}
 				y += 1;
@@ -666,7 +652,7 @@ class ImageDataUtil {
 			while (y >= 0 ) {
 				x = w-1;
 				while (x >= 0) {
-					translatePixel(imgB, sourceImage.rect, image.rect, destPoint, x, y, strength, fromPreMult);
+					translatePixel(imgB, sourceImage.rect, image.rect, destPoint, x, y, strength);
 					x -= 1;
 				}
 				y -= 1;
@@ -698,16 +684,19 @@ class ImageDataUtil {
 
 	inline private static function translatePixel(imgB:UInt8Array, sourceRect:Rectangle, destRect:Rectangle,
 												  destPoint:Vector2, destX: Int, destY: Int,
-												  strength: Float,
-												  fromPreMult: Float -> Float -> Int) {
-		var d: Int = 4 * (destY * Std.int(destRect.width) + destX);
-		var s: Int = calculateSourceOffset(sourceRect, destPoint, destX, destY);
-		var a: Int = if (s >= 0) Std.int(imgB[ s + 3 ] * strength ) else 0;
-		a = a < 0 ? 0 : (a > 255 ? 255 : a);
-		imgB[ d ] = if (s >= 0) fromPreMult( imgB[ s ], a ) else 0;
-		imgB[ d + 1 ] = if (s >= 0) fromPreMult( imgB[ s + 1 ], a ) else 0;
-		imgB[ d + 2 ] = if (s >= 0) fromPreMult( imgB[ s + 2 ], a ) else 0;
-		imgB[ d + 3 ] = a;
+												  strength: Float) {
+		var d = 4 * (destY * Std.int(destRect.width) + destX);
+		var s = calculateSourceOffset(sourceRect, destPoint, destX, destY);
+		if (s < 0) {
+			imgB[d] = imgB[d + 1] = imgB[d + 2] = imgB[d + 3] = 0;
+		} else {
+			imgB[ d ] = imgB[ s ];
+			imgB[ d + 1 ] = imgB[ s + 1 ];
+			imgB[ d + 2 ] = imgB[ s + 2 ];
+
+			var a = Std.int(imgB[ s + 3 ] * strength);
+			imgB[ d + 3 ] = a < 0 ? 0 : (a > 255 ? 255 : a);
+		}
 	}
 	
 	public static function getColorBoundsRect (image:Image, mask:Int, color:Int, findColor:Bool, format:PixelFormat):Rectangle {


### PR DESCRIPTION
there were several issues here:

 - `translatePixel` tried to un-premultiply alpha from colors when working with non-premultiplied images
 - it used the already scaled-by-strength alpha for that
 - it didn't care about whether the image was premultiplied when writing the value back

so, since the only usage of this function in our openfl is on non-premultiplied images, and it didn't work correctly anyway, i just added a `throw` for the premultiplied bitmaps, which is arguably better than breaking them silently

and of course, now when it's sure it works with non-premultiplied images, it can just extract color directly, so `translatePixel` is simplier and doesn't screw up the colors, which fixes artifacts/wrong colors we see when using `GlowFilter`/`DropShadowFilter` 