### PR TITLE
use `get` property access specifier instead of long-deprecated (and not working anymore in haxe4) `get_<propname>`

### DIFF
--- a/haxe/io/Bytes.hx
+++ b/haxe/io/Bytes.hx
@@ -597,7 +597,7 @@ class Bytes {
 #else
 
 
-#if !nodejs
+#if (!nodejs && !haxe4)
 import js.html.compat.Uint8Array;
 import js.html.compat.DataView;
 #end

--- a/lime/graphics/cairo/Cairo.hx
+++ b/lime/graphics/cairo/Cairo.hx
@@ -36,7 +36,9 @@ class Cairo {
 	public var lineWidth (get, set):Float;
 	public var matrix (get, set):Matrix3;
 	public var miterLimit (get, set):Float;
+	#if !haxe4
 	public var operator (get, set):CairoOperator;
+	#end
 	public var source (get, set):CairoPattern;
 	public var target (get, null):CairoSurface;
 	public var tolerance (get, set):Float;
@@ -790,7 +792,12 @@ class Cairo {
 	}
 	
 	
-	@:noCompletion private function get_operator ():CairoOperator {
+	#if !haxe4
+	@:noCompletion private function get_operator ():CairoOperator return getOperator();
+	@:noCompletion private function set_operator (value:CairoOperator):CairoOperator return setOperator(value);
+	#end
+
+	public function getOperator ():CairoOperator {
 		
 		#if (lime_cffi && lime_cairo && !macro)
 		return NativeCFFI.lime_cairo_get_operator (handle);
@@ -801,7 +808,7 @@ class Cairo {
 	}
 	
 	
-	@:noCompletion private function set_operator (value:CairoOperator):CairoOperator {
+	public function setOperator (value:CairoOperator):CairoOperator {
 		
 		#if (lime_cffi && lime_cairo && !macro)
 		NativeCFFI.lime_cairo_set_operator (handle, value);

--- a/lime/project/HXProject.hx
+++ b/lime/project/HXProject.hx
@@ -44,7 +44,7 @@ class HXProject {
 	public var haxedefs:Map<String, Dynamic>;
 	public var haxeflags:Array<String>;
 	public var haxelibs:Array<Haxelib>;
-	public var host (get_host, null):Platform;
+	public var host (get, never):Platform;
 	public var icons:Array<Icon>;
 	public var javaPaths:Array<String>;
 	public var keystore:Keystore;
@@ -62,7 +62,7 @@ class HXProject {
 	public var target:Platform;
 	public var targetFlags:Map<String, String>;
 	public var targetHandlers:Map<String, String>;
-	public var templateContext (get_templateContext, null):Dynamic;
+	public var templateContext (get, never):Dynamic;
 	public var templatePaths:Array<String>;
 	@:isVar public var window (get, set):WindowData;
 	public var windows:Array<WindowData>;

--- a/lime/tools/helpers/PlatformHelper.hx
+++ b/lime/tools/helpers/PlatformHelper.hx
@@ -9,8 +9,8 @@ import sys.io.Process;
 class PlatformHelper {
 	
 	
-	public static var hostArchitecture (get_hostArchitecture, null):Architecture;
-	public static var hostPlatform (get_hostPlatform, null):Platform;
+	public static var hostArchitecture (get, never):Architecture;
+	public static var hostPlatform (get, never):Platform;
 	
 	private static var _hostArchitecture:Architecture;
 	private static var _hostPlatform:Platform;

--- a/lime/tools/helpers/ProcessHelper.hx
+++ b/lime/tools/helpers/ProcessHelper.hx
@@ -13,7 +13,7 @@ class ProcessHelper {
 	
 	
 	public static var dryRun:Bool = false;
-	public static var processorCores (get_processorCores, null):Int;
+	public static var processorCores (get, never):Int;
 	
 	private static var _processorCores:Int = 0;
 	


### PR DESCRIPTION
also use `never` instead of `null`, since these properties are non-physical