### PR TITLE
dispatch window.onRestore when leaving full screen

### DIFF
--- a/lime/_backend/html5/HTML5Window.hx
+++ b/lime/_backend/html5/HTML5Window.hx
@@ -329,6 +329,8 @@ class HTML5Window {
 			isFullscreen = false;
 			parent.__fullscreen = false;
 			
+			parent.onRestore.dispatch ();
+			
 			var changeEvents = [ "fullscreenchange", "mozfullscreenchange", "webkitfullscreenchange", "MSFullscreenChange" ];
 			var errorEvents = [ "fullscreenerror", "mozfullscreenerror", "webkitfullscreenerror", "MSFullscreenError" ];
 			


### PR DESCRIPTION
Dispatch the `onRestore` event when leaving fullscreen on HTML5, so we can handle it in OpenFL's `Stage`.

(this is also how it's currently done in the [upstream](https://github.com/openfl/lime/blob/08df29fe0c492f7c102cc811ec2f8b4896e77b6d/src/lime/_internal/backend/html5/HTML5Window.hx#L487))