### PR TITLE
Fix HTML5 paste event handling

### DIFF
--- a/lime/_backend/html5/HTML5Window.hx
+++ b/lime/_backend/html5/HTML5Window.hx
@@ -536,18 +536,17 @@ class HTML5Window {
 	
 	private function handlePasteEvent (event:ClipboardEvent):Void {
 		
-		if (untyped event.clipboardData.types.indexOf ("text/plain") > -1) {
+		event.preventDefault ();
+		
+		var text = event.clipboardData.getData ("text/plain");
+		if (text == "") return;
+		
+		text = normalizeInputNewlines (text);
+		Clipboard.text = text;
+		
+		if (enableTextEvents) {
 			
-			var text = normalizeInputNewlines (event.clipboardData.getData ("text/plain"));
-			Clipboard.text = text;
-			
-			if (enableTextEvents) {
-				
-				parent.onTextInput.dispatch (text);
-				
-			}
-			
-			event.preventDefault ();
+			parent.onTextInput.dispatch (text);
 			
 		}
 		


### PR DESCRIPTION
MS Edge has a bug with `clipboardData.types` not being an Array and thus not having `indexOf`, so the handler fails with an exception. But we can just `getData` and check if it's an empty string.

Also let's do `preventDefault()` before doing anything else, because both `Clipboard.text` setter and `onTextInput` handlers can throw exceptions, but we still want to prevent the default handling.