### PR TITLE
Rework copy-paste functionality

### DIFF
--- a/lime/system/Clipboard.hx
+++ b/lime/system/Clipboard.hx
@@ -72,31 +72,42 @@ class Clipboard {
 	}
 	
 	
-	private static function set_text (value:String):String {
+	private static inline function set_text (value:String):String {
+		
+		setText (value, true);
+		
+		return value;
+		
+	}
+	
+	
+	public static function setText (value:String, syncSystemClipboard:Bool) {
 		
 		var cacheText = _text;
 		_text = value;
 		
-		#if (lime_cffi && !macro)
-		NativeCFFI.lime_clipboard_set_text (value);
-		#elseif flash
-		FlashClipboard.generalClipboard.setData (TEXT_FORMAT, value);
-		#elseif (js && html5)
-		var window = Application.current.window;
-		if (window != null) {
+		if (syncSystemClipboard) {
 			
-			window.backend.setClipboard (value);
+			#if (lime_cffi && !macro)
+			NativeCFFI.lime_clipboard_set_text (value);
+			#elseif flash
+			FlashClipboard.generalClipboard.setData (TEXT_FORMAT, value);
+			#elseif (js && html5)
+			var window = Application.current.window;
+			if (window != null) {
+				
+				window.backend.setClipboard (value);
+				
+			}
+			#end
 			
 		}
-		#end
 		
 		if (_text != cacheText) {
 			
 			onUpdate.dispatch ();
 			
 		}
-		
-		return value;
 		
 	}
 	

--- a/lime/ui/Window.hx
+++ b/lime/ui/Window.hx
@@ -17,6 +17,9 @@ import flash.display.Stage;
 typedef Stage = Dynamic;
 #end
 
+typedef CopyDataProvider = String->Void;
+
+
 #if !lime_debug
 @:fileXml('tags="haxe,release"')
 @:noDebug
@@ -61,6 +64,9 @@ class Window {
 	public var onRestore = new Event<Void->Void> ();
 	public var onTextEdit = new Event<String->Int->Int->Void> ();
 	public var onTextInput = new Event<String->Void> ();
+	public var onTextCopy = new Event<CopyDataProvider->Void> ();
+	public var onTextCut = new Event<CopyDataProvider->Void> ();
+	public var onTextPaste = new Event<String->Void> ();
 	public var renderer:Renderer;
 	public var resizable (get, set):Bool;
 	public var scale (get, null):Float;


### PR DESCRIPTION
The Window object now provide distinct cut/copy/paste signals for the upper level (i.e. OpenFL) which can actually provide the data for the clipboard.
Also cleaned up the flow with syncing between system clipboard and lime's Clipboard, no redundant events are fired/handled now.

The corresponding OpenFL PR will come after this.